### PR TITLE
Case-Insensitive map class

### DIFF
--- a/UtilitiesEx/CMakeLists.txt
+++ b/UtilitiesEx/CMakeLists.txt
@@ -3,6 +3,7 @@ project(UtilitiesEx-SRC VERSION 0.0.0 LANGUAGES CXX)
 include(TargetMacros)
 set(UtilitiesEx_SRCS Mathematician/Combinatorics.cpp)
 set(UtilitiesEx_INCLUDES Any.hpp
+                         Containers/CaseInsensitiveMap.hpp
                          Mathematician/Combinatorics.hpp
                          IterTools/Combinations.hpp
                          TypeTraits/IteratorTypes.hpp

--- a/UtilitiesEx_Test/CMakeLists.txt
+++ b/UtilitiesEx_Test/CMakeLists.txt
@@ -4,6 +4,7 @@ include(TargetMacros)
 
 add_cxx_unit_test(TestAny)
 add_cxx_unit_test(Testtype_traitsExtensions)
+add_cxx_unit_test(TestCaseInsensitiveMap)
 add_cxx_unit_test(TestCombinations)
 add_cxx_unit_test(TestCombinatorics)
 add_cxx_unit_test(TestIteratorTypes)

--- a/UtilitiesEx_Test/TestCaseInsensitiveMap.cpp
+++ b/UtilitiesEx_Test/TestCaseInsensitiveMap.cpp
@@ -1,0 +1,109 @@
+#include <UtilitiesEx/Containers/CaseInsensitiveMap.hpp>
+#include <catch/catch.hpp>
+
+using namespace UtilitiesEx;
+
+// Note that the actual CaseInsensitiveMap is just a typedef so this test
+// focuses on the less than comparer which actually bestows the case
+// insensitive property.
+
+TEST_CASE("CaseInsensitiveLess_::LetterComparer_")
+{
+    detail_::CaseInsensitiveLess_::LetterComparer_ fxn;
+
+    SECTION("Both lowercase")
+    {
+        REQUIRE(fxn('a', 'b'));
+        REQUIRE(!fxn('b', 'a'));
+        REQUIRE(!fxn('a', 'a'));
+    }
+
+    SECTION("Left uppercase, right lower")
+    {
+        REQUIRE(fxn('A', 'b'));
+        REQUIRE(!fxn('B', 'a'));
+        REQUIRE(!fxn('A', 'a'));
+    }
+
+    SECTION("Left lowercase, right upper")
+    {
+        REQUIRE(fxn('a', 'B'));
+        REQUIRE(!fxn('b', 'A'));
+        REQUIRE(!fxn('a', 'A'));
+    }
+
+    SECTION("Both uppercase")
+    {
+        REQUIRE(fxn('A', 'B'));
+        REQUIRE(!fxn('B', 'A'));
+        REQUIRE(!fxn('A', 'A'));
+    }
+}
+
+TEST_CASE("CaseInsensitiveLess_")
+{
+
+    detail_::CaseInsensitiveLess_ fxn;
+    SECTION("Both lowercase")
+    {
+        REQUIRE(fxn("abcde", "bcdef"));
+        REQUIRE(!fxn("bcdef", "abcde"));
+        REQUIRE(!fxn("abcde", "abcde"));
+    }
+
+    SECTION("Left uppercase, right lower")
+    {
+        REQUIRE(fxn("ABCDE", "bcdef"));
+        REQUIRE(!fxn("BCDEF", "abcde"));
+        REQUIRE(!fxn("ABCDE", "abcde"));
+    }
+
+    SECTION("Left lowercase, right upper")
+    {
+        REQUIRE(fxn("abcde", "BCDEF"));
+        REQUIRE(!fxn("bcdef", "ABCDE"));
+        REQUIRE(!fxn("abcde", "ABCDE"));
+    }
+
+    SECTION("Both uppercase")
+    {
+        REQUIRE(fxn("ABCDE", "BCDEF"));
+        REQUIRE(!fxn("BCDEF", "ABCDE"));
+        REQUIRE(!fxn("ABCDE", "ABCDE"));
+    }
+
+    SECTION("Mixed case")
+    {
+        REQUIRE(fxn("aB", "bC"));
+        REQUIRE(fxn("aB", "Bc"));
+        REQUIRE(fxn("Ab", "bC"));
+        REQUIRE(fxn("Ab", "Cb"));
+    }
+}
+
+TEST_CASE("CaseInsensitiveMap")
+{
+    CaseInsensitiveMap<int> a_map;
+
+    SECTION("Before add")
+    {
+        REQUIRE(!a_map.count("abc"));
+        REQUIRE(!a_map.count("Abc"));
+        REQUIRE(!a_map.count("ABc"));
+        REQUIRE(!a_map.count("AbC"));
+        REQUIRE(!a_map.count("aBC"));
+        REQUIRE(!a_map.count("ABC"));
+    }
+
+    a_map["abc"] = 2;
+
+    SECTION("After add")
+    {
+        REQUIRE(a_map.count("abc"));
+        REQUIRE(a_map.count("Abc"));
+        REQUIRE(a_map.count("ABc"));
+        REQUIRE(a_map.count("AbC"));
+        REQUIRE(a_map.count("aBC"));
+        REQUIRE(a_map.count("ABC"));
+    }
+}


### PR DESCRIPTION
## Status

- [x] Ready to go

## Brief Description

Using `std::string` as a key in an `std::map` is super common.  Unfortunately keys in such a map are
case sensitive.  Often times we want to ignore differences in case and this class wraps the `std::map` class to make it case insensitive (in the keys).

## Detailed Description

## TODOs and/or Questions

- [x] Write the class
- [x] Test the class