### PR TITLE
Change install folder's name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(utilities VERSION 1.0.0)
+set(CPP_NAMESPACE Utilities)
 find_package(cpp REQUIRED)
-
 cpp_option(BUILD_TESTS ON)
 cpp_find_or_build_dependency(Catch2 URL github.com/catchorg/Catch2)
 


### PR DESCRIPTION
CPP defaults to lowercase names.  At the moment most of our projects use uppercase.  This PR modifies CPP's default.
