### PR TITLE
Slight Refactoring of Iterator Base Classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,11 @@ project(utilities VERSION 1.0.0)
 set(CPP_NAMESPACE Utilities)
 find_package(cpp REQUIRED)
 cpp_option(BUILD_TESTS ON)
-cpp_find_or_build_dependency(NAME Catch2 URL github.com/catchorg/Catch2)
 
 add_subdirectory(Utilities)
 
 if(BUILD_TESTS)
+    cpp_find_or_build_dependency(NAME Catch2 URL github.com/catchorg/Catch2)
     enable_testing()
     add_subdirectory(Utilities_Test)
 endif()

--- a/Utilities/IterTools/Combinations.hpp
+++ b/Utilities/IterTools/Combinations.hpp
@@ -34,6 +34,7 @@ class CombinationItr : public detail_::RandomAccessIteratorBase<
     /// Typedefs forwarded from the base class
     ///@{
     using value_type      = typename base_type::value_type;
+    using reference       = typename base_type::reference;
     using const_reference = typename base_type::const_reference;
     using size_type       = typename base_type::size_type;
     using difference_type = typename base_type::difference_type;
@@ -77,92 +78,6 @@ class CombinationItr : public detail_::RandomAccessIteratorBase<
         update_comb();
     }
 
-    /** @brief Returns a read-only version of the element currently pointed to
-     *         by this iterator.
-     *
-     *
-     *  @return The element being pointed to.
-     *  @throws None No throw guarantee.
-     */
-    const_reference dereference() const noexcept { return comb_; }
-
-    /** @brief Makes the iterator point to the next Combination.
-     *
-     *  Combinations are ordered lexicographically and "next" follows from
-     *  this convention.
-     *
-     *  @warning Incrementing beyond the end of the container is allowed;
-     *           however, dereferencing the corresponding iterator is
-     *           undefined behavior.
-     *
-     *  @return The iterator after incrementing
-     *  @throws None No throw guarantee.
-     */
-    CombinationItr& increment() noexcept {
-        ++current_perm_;
-        update_comb();
-        return *this;
-    }
-
-    /** @brief Makes the iterator point to the previous Combination.
-     *
-     *  Combinations are ordered lexicographically and "previous" follows
-     *  from this convention.
-     *
-     *  @warning Decrementing beyond the beginning of the container is
-     *           allowed; however, dereferencing the corresponding iterator
-     *           is undefined behavior.
-     *
-     *  @return The iterator after decrementing
-     *  @throws None No throw guarantee.
-     */
-    CombinationItr& decrement() noexcept {
-        --current_perm_;
-        update_comb();
-        return *this;
-    }
-
-    /** @brief Moves the current iterator @p n iterations
-     *
-     *  @param[in] n The number of iterations to move the iterator.  Can
-     *             be either forward or backward.
-     *  @returns The current iterator pointing at the element @p n
-     *           iterations away.
-     *  @throws ??? if update_comb() throws same throw guarantee.
-     *
-     */
-    CombinationItr& advance(difference_type n) {
-        current_perm_ += n;
-        update_comb();
-        return *this;
-    }
-
-    /** Compares two CombinationItrs for exact equality
-     *
-     *  Exact equality is defined as pointing to the same Combination,
-     *  having the same starting Combination, and having both wrapped (or
-     *  not wrapped).
-     *
-     *  @param[in] other The iterator to compare to.
-     *  @return True if this iterator is exactly the same as @p other
-     *  @throws None No throw guarantee.  We assume that SequenceType's equality
-     *          operator is also no throw.
-     */
-    bool are_equal(const CombinationItr& other) const noexcept {
-        return std::tie(set_, current_perm_) ==
-               std::tie(other.set_, other.current_perm_);
-    }
-
-    /** @brief Returns the distance between this iterator and another
-     *
-     * @param[in] rhs The iterator we want the distance to.
-     * @returns the distance between the two iterators
-     * @throw None No throw guarantee
-     */
-    difference_type distance_to(const CombinationItr& rhs) const noexcept {
-        return current_perm_ - rhs.current_perm_;
-    }
-
     /**
      * @brief Exchanges the current iterator's state with that of another
      * instance.
@@ -179,7 +94,7 @@ class CombinationItr : public detail_::RandomAccessIteratorBase<
         std::swap(current_perm_, rhs.current_perm_);
     }
 
-    private:
+private:
     /// A copy of the parent's set
     value_type set_;
 
@@ -208,6 +123,91 @@ class CombinationItr : public detail_::RandomAccessIteratorBase<
         }
     }
 
+    /** @brief Returns a read-only version of the element currently pointed to
+     *         by this iterator.
+     *
+     *
+     *  @return The element being pointed to.
+     *  @throws None No throw guarantee.
+     */
+    reference dereference_() override { return comb_; }
+
+    /** @brief Makes the iterator point to the next Combination.
+     *
+     *  Combinations are ordered lexicographically and "next" follows from
+     *  this convention.
+     *
+     *  @warning Incrementing beyond the end of the container is allowed;
+     *           however, dereferencing the corresponding iterator is
+     *           undefined behavior.
+     *
+     *  @return The iterator after incrementing
+     *  @throws None No throw guarantee.
+     */
+    CombinationItr& increment_() override {
+        ++current_perm_;
+        update_comb();
+        return *this;
+    }
+
+    /** @brief Makes the iterator point to the previous Combination.
+     *
+     *  Combinations are ordered lexicographically and "previous" follows
+     *  from this convention.
+     *
+     *  @warning Decrementing beyond the beginning of the container is
+     *           allowed; however, dereferencing the corresponding iterator
+     *           is undefined behavior.
+     *
+     *  @return The iterator after decrementing
+     *  @throws None No throw guarantee.
+     */
+    CombinationItr& decrement_() override {
+        --current_perm_;
+        update_comb();
+        return *this;
+    }
+
+    /** @brief Moves the current iterator @p n iterations
+     *
+     *  @param[in] n The number of iterations to move the iterator.  Can
+     *             be either forward or backward.
+     *  @returns The current iterator pointing at the element @p n
+     *           iterations away.
+     *  @throws ??? if update_comb() throws same throw guarantee.
+     *
+     */
+    CombinationItr& advance_(difference_type n) override {
+        current_perm_ += n;
+        update_comb();
+        return *this;
+    }
+
+    /** Compares two CombinationItrs for exact equality
+     *
+     *  Exact equality is defined as pointing to the same Combination,
+     *  having the same starting Combination, and having both wrapped (or
+     *  not wrapped).
+     *
+     *  @param[in] other The iterator to compare to.
+     *  @return True if this iterator is exactly the same as @p other
+     *  @throws None No throw guarantee.  We assume that SequenceType's equality
+     *          operator is also no throw.
+     */
+    bool are_equal_(const CombinationItr& other) const noexcept override {
+        return std::tie(set_, current_perm_) ==
+               std::tie(other.set_, other.current_perm_);
+    }
+
+    /** @brief Returns the distance between this iterator and another
+     *
+     * @param[in] rhs The iterator we want the distance to.
+     * @returns the distance between the two iterators
+     * @throw None No throw guarantee
+     */
+    difference_type distance_to_(const CombinationItr& rhs) const override {
+        return current_perm_ - rhs.current_perm_;
+    }
 }; // End class CombinationItr
 
 } // End namespace detail_

--- a/Utilities/IterTools/Permutations.hpp
+++ b/Utilities/IterTools/Permutations.hpp
@@ -43,6 +43,7 @@ class PermutationItr
     /// Brings some of base class's typedefs into scope
     ///@{
     using value_type      = typename base_type::value_type;
+    using reference = typename base_type::reference;
     using const_reference = typename base_type::const_reference;
     using difference_type = typename base_type::difference_type;
     using size_type       = typename base_type::size_type;
@@ -90,19 +91,37 @@ class PermutationItr
       offset_(offset),
       dx_(permutation_to_decimal(input_set, sorted_orig_)) {}
 
-    /** @brief Allows access to the current permutation.
+    /**
+     * @brief Swaps the state of the current instance with that of another.
      *
-     *  In accordance with usual C++ practice the element is returned by
-     *  reference.  However, any changes made to the element will be overridden
-     *  when the iterator is incremented or decremented.
      *
-     *  @note The base class will use this function to implement both the
-     *  read-only and the read/write dereference operation via const_cast.
-     *
-     *  @return The element being pointed to.
-     *  @throws None. No throw guarantee.
+     * @param rhs the instance to swap with.  After the operation it will
+     *        contain the state of the current instance.
+     * @throw ??? if SequenceType's swap function throws.  Guarantee is no throw
+     *        if SequenceType's swap is also no throw.  Otherwise it is weak at
+     *        best.
      */
-    const_reference dereference() const override { return set_; }
+    void swap(PermutationItr& rhs) {
+        std::swap(orig_set_, rhs.orig_set_);
+        std::swap(sorted_orig_, rhs.sorted_orig_);
+        std::swap(set_, rhs.set_);
+        std::swap(offset_, rhs.offset_);
+        std::swap(dx_, rhs.dx_);
+    }
+protected:
+    /** @brief Allows access to the current permutation.
+ *
+ *  In accordance with usual C++ practice the element is returned by
+ *  reference.  However, any changes made to the element will be overridden
+ *  when the iterator is incremented or decremented.
+ *
+ *  @note The base class will use this function to implement both the
+ *  read-only and the read/write dereference operation via const_cast.
+ *
+ *  @return The element being pointed to.
+ *  @throws None. No throw guarantee.
+ */
+    reference dereference_() override { return set_; }
 
     /** @brief Makes the iterator point to the next permutation.
      *
@@ -121,7 +140,7 @@ class PermutationItr
      *          std::next_permutation throws given the resulting iterators.
      *          Same throw guarantee as the throwing function.
      */
-    PermutationItr& increment() {
+    PermutationItr& increment_() override {
         std::next_permutation(set_.begin(), set_.end());
         ++offset_;
         return *this;
@@ -145,7 +164,7 @@ class PermutationItr
      *  @return True if this iterator is exactly the same as @p rhs
      *  @throws None No throw guarantee.
      */
-    bool are_equal(const PermutationItr& rhs) const noexcept {
+    bool are_equal_(const PermutationItr& rhs) const noexcept override {
         return std::tie(orig_set_, set_, offset_) ==
                std::tie(rhs.orig_set_, rhs.set_, rhs.offset_);
     }
@@ -167,7 +186,7 @@ class PermutationItr
      *          if prev_permutation throws with the resulting iterators.  Same
      *          guarantee as the throwing function.
      */
-    PermutationItr& decrement() {
+    PermutationItr& decrement_() override {
         std::prev_permutation(set_.begin(), set_.end());
         --offset_;
         return *this;
@@ -188,7 +207,7 @@ class PermutationItr
      *          memory to complete.  Strong throw guarantee.
      *
      */
-    PermutationItr& advance(difference_type n) {
+    PermutationItr& advance_(difference_type n) override {
         set_ = decimal_to_permutation(offset_ + dx_ + n, sorted_orig_);
         offset_ += n; // After above call for strong throw guarantee
         return *this;
@@ -218,31 +237,13 @@ class PermutationItr
      *
      *
      */
-    difference_type distance_to(const PermutationItr& rhs) const {
+    difference_type distance_to_(const PermutationItr& rhs) const override {
         difference_type ddx  = UnsignedSubtract(rhs.dx_, dx_);
         difference_type doff = UnsignedSubtract(rhs.offset_, offset_);
         return ddx + doff;
     }
 
-    /**
-     * @brief Swaps the state of the current instance with that of another.
-     *
-     *
-     * @param rhs the instance to swap with.  After the operation it will
-     *        contain the state of the current instance.
-     * @throw ??? if SequenceType's swap function throws.  Guarantee is no throw
-     *        if SequenceType's swap is also no throw.  Otherwise it is weak at
-     *        best.
-     */
-    void swap(PermutationItr& rhs) {
-        std::swap(orig_set_, rhs.orig_set_);
-        std::swap(sorted_orig_, rhs.sorted_orig_);
-        std::swap(set_, rhs.set_);
-        std::swap(offset_, rhs.offset_);
-        std::swap(dx_, rhs.dx_);
-    }
-
-    private:
+private:
     /// A copy of the parent's set, doesn't get modified
     value_type orig_set_;
 

--- a/Utilities/IterTools/Range.hpp
+++ b/Utilities/IterTools/Range.hpp
@@ -27,11 +27,12 @@ class RangeItr
       detail_::RandomAccessIteratorBase<RangeItr<element_type>, element_type>;
 
     public:
-    /// Pulls the const_reference typedef into scope
-    using const_reference = const element_type&;
-
-    /// Pulls the difference_type typedef into scope
+    /// Pulls some typedefs into scope
+    ///@{
+    using reference = typename base_type::reference;
+    using const_reference = typename base_type::const_reference;
     using typename base_type::difference_type;
+    ///@}
 
     /**
      * @brief Makes a default RangeItr instance.
@@ -105,7 +106,7 @@ class RangeItr
     RangeItr(element_type start, element_type stop, difference_type increment) :
       start_(start),
       stop_(stop),
-      increment_(increment),
+      shift_(increment),
       value_(start_) {}
 
     private:
@@ -113,22 +114,22 @@ class RangeItr
     friend base_type;
 
     /// Implements operator*()
-    const_reference dereference() const override { return value_; }
+    reference dereference_() override { return value_; }
 
     /// Implements operator++
-    RangeItr& increment() override { return advance(increment_); }
+    RangeItr& increment_() override { return advance_(shift_); }
 
     /// Implements operator--
-    RangeItr& decrement() override { return advance(-1 * increment_); }
+    RangeItr& decrement_() override { return advance_(-1 * shift_); }
 
     /// Implements operator+=
-    RangeItr& advance(difference_type adv) override {
+    RangeItr& advance_(difference_type adv) override {
         adv > 0 ? value_ += adv : value_ -= -1 * adv;
         return *this;
     }
 
     /// Implements itr1 - itr2
-    difference_type distance_to(const RangeItr& rhs) const noexcept {
+    difference_type distance_to_(const RangeItr& rhs) const noexcept {
         const bool is_positive = rhs.value_ > value_;
         difference_type abs_diff =
           is_positive ? rhs.value_ - value_ : value_ - rhs.value_;
@@ -146,7 +147,7 @@ class RangeItr
      *  otherwise.
      *  @throw None. No throw guarantee.
      */
-    bool are_equal(const RangeItr& rhs) const noexcept {
+    bool are_equal_(const RangeItr& rhs) const noexcept {
         return value_ == rhs.value_;
     }
 
@@ -157,7 +158,7 @@ class RangeItr
     element_type stop_ = 0;
 
     /// The amount to increment by
-    difference_type increment_ = 1;
+    difference_type shift_ = 1;
 
     /// The current value of the iterator
     element_type value_ = 0;

--- a/Utilities/IterTools/TupleContainer.hpp
+++ b/Utilities/IterTools/TupleContainer.hpp
@@ -352,13 +352,10 @@ class TupleContainerImpl {
         }
 
         /// Implements the means by which this class can be dereferenced
-        reference dereference() { return buffer_; }
-
-        /// Implements the mechanism for dereferencing a read-only iterator
-        const_reference dereference() const { return buffer_; }
+        reference dereference_() override { return buffer_; }
 
         /// Implements the mechansim for incrementing this iterator
-        TupleContainerIterator& increment() noexcept {
+        TupleContainerIterator& increment_() override {
             IncrementFunctor f;
             f.run(start_, end_, value_,
                   std::make_index_sequence<ncontainers_>());
@@ -368,7 +365,8 @@ class TupleContainerImpl {
 
         /// Implements the mechanism for checking if this iterator equals
         /// another
-        bool are_equal(const TupleContainerIterator& rhs) const noexcept {
+        bool are_equal_(const TupleContainerIterator& rhs) const noexcept
+        override {
             return value_ == rhs.value_;
         }
 

--- a/Utilities_Test/TestCombinations.cpp
+++ b/Utilities_Test/TestCombinations.cpp
@@ -35,9 +35,9 @@ void check_state(comb_itr<repeat> start, const comb_itr<repeat>& end,
             comb_itr<repeat> tmp{orig, corr[i].size(), false};
             for(std::size_t j = 0; j < i; ++j) ++tmp;
             const long dx = static_cast<long>(i) - counter;
-            REQUIRE(start.distance_to(tmp) == dx);
+            REQUIRE(start - tmp == dx);
             comb_itr<repeat> copy{start};
-            REQUIRE(copy.advance(dx) == tmp);
+            REQUIRE((copy += dx) == tmp);
         }
         REQUIRE(*start++ == corr[counter++]);
     }

--- a/Utilities_Test/TestIteratorTypes.cpp
+++ b/Utilities_Test/TestIteratorTypes.cpp
@@ -8,14 +8,15 @@ using namespace detail_;
 struct Iterator : public InputIteratorBase<Iterator, int> {
     int value_ = 0;
 
-    Iterator& increment() {
+protected:
+    Iterator& increment_() {
         ++value_;
         return *this;
     }
 
-    const int& dereference() const { return value_; }
+    int& dereference_() { return value_; }
 
-    bool are_equal(const Iterator& other) const noexcept {
+    bool are_equal_(const Iterator& other) const noexcept {
         return value_ == other.value_;
     }
 };
@@ -62,20 +63,20 @@ TEST_CASE("InputIterator base class") {
 struct BidirectionalIterator
   : public BidirectionalIteratorBase<BidirectionalIterator, int> {
     int value_ = 0;
-
-    BidirectionalIterator& increment() {
+protected:
+    BidirectionalIterator& increment_() {
         ++value_;
         return *this;
     }
 
-    BidirectionalIterator& decrement() {
+    BidirectionalIterator& decrement_() {
         --value_;
         return *this;
     }
 
-    const int& dereference() const { return value_; }
+    int& dereference_() { return value_; }
 
-    bool are_equal(const BidirectionalIterator& other) const noexcept {
+    bool are_equal_(const BidirectionalIterator& other) const noexcept {
         return value_ == other.value_;
     }
 };
@@ -102,28 +103,28 @@ TEST_CASE("BidirectionalIterator base class") {
 struct RandomAccessIterator
   : public RandomAccessIteratorBase<RandomAccessIterator, int> {
     int value_ = 0;
-
-    RandomAccessIterator& increment() {
+protected:
+    RandomAccessIterator& increment_() {
         ++value_;
         return *this;
     }
 
-    RandomAccessIterator& decrement() {
+    RandomAccessIterator& decrement_() {
         --value_;
         return *this;
     }
 
-    const int& dereference() const { return value_; }
+    int& dereference_() { return value_; }
 
-    bool are_equal(const RandomAccessIterator& other) const noexcept {
+    bool are_equal_(const RandomAccessIterator& other) const noexcept {
         return value_ == other.value_;
     }
 
-    long int distance_to(const RandomAccessIterator& other) const noexcept {
+    long int distance_to_(const RandomAccessIterator& other) const noexcept {
         return other.value_ - value_;
     }
 
-    RandomAccessIterator& advance(long int n) {
+    RandomAccessIterator& advance_(long int n) {
         value_ += n;
         return *this;
     }

--- a/Utilities_Test/TestPermutations.cpp
+++ b/Utilities_Test/TestPermutations.cpp
@@ -21,9 +21,9 @@ void check_state(perm_itr& b, const perm_itr& end,
             perm_itr temp{corr[pstart], 0};
             long dx = static_cast<long>(pstart) - counter;
 
-            REQUIRE(b.distance_to(temp) == dx);
+            REQUIRE(b - temp == dx);
             perm_itr copyb{b};
-            REQUIRE(*(copyb.advance(dx)) == *temp);
+            REQUIRE(*(copyb+=dx) == *temp);
         }
         REQUIRE(*b++ == corr[counter++]);
     }


### PR DESCRIPTION
## Status
<!--- Please check this box when your PR is ready--->
- [x] Ready to go

## Description

While starting to implement the classes needed for the revised SDE plan I had need to roll my own iterator. Looking back at the iterator base classes contained in this repo I realized that there were a couple things I could do better:

- Methods designed to be implemented by derived classes should not be public.
- The method for retrieving elements by reference should be non-const and then cast to cost to implement the const version.
   - I originally had it the other way.

This PR fixes the above points and adjusts the tests accordingly.
