### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Actions](https://github.com/hjjvandam/Utilities/workflows/C_C++_CI/badge.svg)](https://github.com/hjjvandam/Utilities)
+[![Actions](https://github.com/NWChemEx-Project/Utilities/workflows/C_C++_CI/badge.svg)](https://github.com/NWChemEx-Project/Utilities)
 
-[![Codecov](https://codecov.io/github/hjjvandam/Utilities/branch/github-actions/graphs/sunburst.svg?token=C0Za4faanD)](https://codecov.io/github/hjjvandam/Utilities/branch/github-actions)
+[![Codecov](https://codecov.io/github/NWChemEx-Project/Utilities/branch/master/graphs/sunburst.svg?token=gdemefzIU7)](https://codecov.io/github/NWChemEx-Project/Utilities/branch/master)
 
 Utilities Repository
 ======================


### PR DESCRIPTION
Now the github-actions changes have been merged the links on the README page need to be fixed to point at the right repo and branch.

## Status
<!--- Please check this box when your PR is ready--->
- [x] Ready to go

## Brief Description

The CI and Codecov work based off the repo and branch names. Hence when code moves by merging to another repo and branch the links to the results "break" (they point to the wrong place, but are still valid until the old branch is deleted). This PR fixes the links on the README page so that the results shown reflect the actual status of the NWChemEx-Project Utilities repo master branch.




