### PR TITLE
Adds a workflow for auto-linting master

### DIFF
--- a/.github/workflows/c-cpp.yaml
+++ b/.github/workflows/c-cpp.yaml
@@ -12,12 +12,6 @@ jobs:
     - uses: actions/setup-python@v1
       with: 
          python-version: '3.x'
-    - name: get-clang-format
-      run:  wget https://raw.githubusercontent.com/NWChemEx-Project/DeveloperTools/master/ci/lint/clang-format.in -O .clang-format
-    - uses: DoozyX/clang-format-lint-action@v0.5
-      with:
-         extensions: 'h,hpp,cpp'
-         clangFormatVersion: 5
     - name: get-gcc
       run: |
             sudo add-apt-repository ppa:ubuntu-toolchain-r/test

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,6 @@
 name: Lint Master
 on:
-  pull_request:
+  push:
     branches:
       - master
 
@@ -9,31 +9,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: obtain-source
+      - name: Obtain Source
         uses: actions/checkout@v2
-#      - name: new-branch
-#        env:
-#          hash_value: ${{ github.sha }}
-#        run: git checkout -b ${hash_value}-#pr
-      - name: get-lint-settings
-        run:  wget https://raw.githubusercontent.com/NWChemEx-Project/DeveloperTools/master/ci/lint/clang-format.in -O .clang-format
-      - name: get-clang-format
+      - name: Get .clang-format.in
+        env:
+          nwx_url: https://raw.githubusercontent.com/NWChemEx-Project
+          clang_format_url: DeveloperTools/master/ci/lint/clang-format.in
+        run:  wget "${nwx_url}/${clang_format_url}" -O .clang-format
+      - name: Get clang-format-9
         run: |
               sudo apt update
               sudo apt-get install -f clang-format-9
-      - name: run-clang-format
+      - name: Run clang-format-9
         run: |
               find utilities -name '*.hpp' -or -name '*.cpp' | xargs clang-format-9 -style=file -i -fallback-style=none
-#      - name: commit-changes
-#        id: changes
-#        run: |
-#              diff_value=`git diff`
-#              if [ ! -z "$diff_value" ]
-#              then
-#                  git config --local user.email "action@github.com"
-#                  git config --local user.name "GitHub Action"
-#                  git commit -m "linted source" -a
-#              fi
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2
         with:


### PR DESCRIPTION
As discussed in #69 I'd like to automate the linting process. This PR does that.

When the workflow works correctly it should:

1. Checkout master whenever code gets pushed to it
2. Create a new branch named `<hash>-#pr` (`<hash>` is the commit hash)
3. Get our `.clang-format` file
4. Run `clang-format` using the file, editing files in place
5. Run `git diff` to determine if any files changed
6. If files changed, commit them and push the changes to a GitHub branch
7. Trigger autopr action (which makes a PR if a branch with the name #pr) is pushed

I highly doubt it does all that at the moment, but we'll see...
