### PR TITLE
Module Documentation Generation

### DIFF
--- a/utilities/printing/word_wrap_stream.cpp
+++ b/utilities/printing/word_wrap_stream.cpp
@@ -28,12 +28,28 @@ protected:
         // Break paragraph into sentences
         auto sentences = strings::split_string(std::string(s, s + n), "\n");
 
+	// Tracks if currently in a table.
+	// A table starts when a line starts with a '+' character and ends when
+	// an empty line is encountered.
+	bool in_table = false;
+	
         const auto nsentences = sentences.size();
         for(std::size_t si = 0; si < nsentences; ++si) { // Loop over sentences
             auto sentence = sentences[si];
+
+	    // Detect start of a table when line starts with '+' character
+	    if (sentence[0] == '+') {
+		in_table = true;
+	    }
+	    // End of table if an empty line is encountered
+	    else if (in_table && sentence.empty()) {
+		in_table = false;
+	    }
+	    
             while(!sentence.empty()) {
                 const unsigned short size = sentence.size();
-                if(m_nchars_ + size <= m_w_) { // Whole thing fits
+		    
+		if(m_nchars_ + size <= m_w_) { // Whole thing fits
                     (*m_os_) << sentence;
                     m_nchars_ += size;
                     break;
@@ -57,7 +73,10 @@ protected:
                     continue;
                 }
 
-                if(no_spaces_left) {
+		// Output the entire line if the remaining characters cannot fit
+		// in an empty line, or we are currently in a table and ignoring
+		// the character limit
+                if(no_spaces_left || in_table) {
                     (*m_os_) << sentence;
                     break;
                 }


### PR DESCRIPTION
## Status
<!--- Please check this box when your PR is ready--->
- [ ] Ready to go

## Brief Description
I am working on adding automatic documentation generation for modules. This requires some changes/fixes in this repository.

## Detailed Description

## TODOs and/or Questions
<!--- When starting a PR early please add a list of things you plan on doing--->
- [ ] Fix WordWrapStream so it does not break up libfort tables at the max character limit for a line.
- [ ] An alternative to the above solution is to ensure WordWrapStream strictly adheres to the max character limit, instead of writing the entire word when it cannot fit the word (space delimited) within the character limit. 
- [ ] Track indentation for bullets in WordWrapStream. Without indentation, it appears that Sphinx cannot render bullets with multiple lines of text properly. Should I work on this?