### PR TITLE
Upgrade Catch2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if("${BUILD_TESTING}")
         URL github.com/catchorg/Catch2
         BUILD_TARGET Catch2
         FIND_TARGET Catch2::Catch2
-        VERSION v2.13.3
+        VERSION v2.13.8
     )
     cpp_add_tests(
         test_utilities


### PR DESCRIPTION
I run into a build failure when I tried compiling with GCC 11. Error was coming from Catch 2 and already [fixed](https://github.com/catchorg/Catch2/issues/2178) in a recent version.

## Status
<!--- Please check this box when your PR is ready--->
- [ ] Ready to go

## Brief Description

## Detailed Description

## TODOs and/or Questions

Is there a way to do this for all repos automatically?
<!--- When starting a PR early please add a list of things you plan on doing--->
