### PR TITLE
Fixed string toupper and tolower functions not compiling

### DIFF
--- a/utilities/strings/string_tools.hpp
+++ b/utilities/strings/string_tools.hpp
@@ -132,10 +132,10 @@ inline auto replace(const std::string& from, const std::string& to,
  */
 inline std::string tolower_string(std::string str) {
     // Lowercase each character in the string
-    std::transform(tmp_str.begin(), tmp_str.end(), tmp_str.begin(),
+    std::transform(str.begin(), str.end(), str.begin(),
                    [](unsigned char c) { return std::tolower(c); });
 
-    return tmp_str;
+    return str;
 }
 
 /** @brief Uppercase the entirety of @p str.
@@ -144,15 +144,12 @@ inline std::string tolower_string(std::string str) {
  *
  * @return A deep copy of @p str with all applicable characters uppercased.
  */
-inline std::string toupper_string(const std::string& str) {
-    // Make a copy
-    std::string tmp_str = str;
-
+inline std::string toupper_string(std::string str) {
     // Uppercase each character in the string
-    std::transform(tmp_str.begin(), tmp_str.end(), tmp_str.begin(),
+    std::transform(str.begin(), str.end(), str.begin(),
                    [](unsigned char c) { return std::toupper(c); });
 
-    return tmp_str;
+    return str;
 }
 
 } // namespace utilities::strings


### PR DESCRIPTION
## Status
<!--- Please check this box when your PR is ready--->
- [x] Ready to go

## Brief Description

In #105, I forgot to test the suggested changes that I accepted into the repo, and it was merged without the CI checks since they were not running. This should fix the compile issues in `tolower_string` and `toupper_string`. I tested the build locally after the changes; the code compiles now and unit tests pass!
