### PR TITLE
CMake Get Versions Before CMaize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,9 @@ set(
     CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${PROJECT_SOURCE_DIR}/cmake"
     CACHE STRING "" FORCE
 )
-include(get_cmaize)
 include(nwx_versions)
+include(get_cmaize)
+
 
 option(BUILD_TESTING "Should we build the tests?" OFF)
 option(BUILD_DOCS "Should we build the documentation?" OFF)


### PR DESCRIPTION
**PR Type**

- [ ] Breaking change
- [ ] Feature
- [x] Patch

**Brief Description**
NWChemEx/NWXCMake#38 moved the CMaize version out of the `get_cmaize` function and into `nwx_versions`. This means that `nwx_versions` needs to be included in CMakeLists.txt before `get_cmaize`, which is what this patch does.

**Not In Scope**

**PR Checklist**

- [ ] [Is documented](https://nwchemex.github.io/.github/documenting/index.html)
- [ ] [Is tested](https://nwchemex.github.io/.github/testing/index.html)
- [ ] [Adheres to applicable organization standards](https://nwchemex.github.io/.github/conventions/index.html)
